### PR TITLE
Add training script

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,129 @@
+import argparse
+import json
+from pathlib import Path
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from torchvision import datasets, models, transforms
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train a pill classifier")
+    parser.add_argument("data_dir", type=Path, help="Path to dataset root with train/val folders")
+    parser.add_argument("--epochs", type=int, default=10, help="Number of training epochs")
+    parser.add_argument("--batch-size", type=int, default=32, help="Batch size")
+    parser.add_argument("--lr", type=float, default=1e-3, help="Max learning rate for OneCycle")
+    parser.add_argument("--output", type=Path, default=Path("outputs"), help="Directory to save model and metrics")
+    parser.add_argument("--num-workers", type=int, default=4, help="Data loader workers")
+    return parser.parse_args()
+
+
+def get_dataloaders(data_dir: Path, batch_size: int, num_workers: int):
+    train_tfm = transforms.Compose([
+        transforms.RandomResizedCrop(224),
+        transforms.RandomHorizontalFlip(),
+        transforms.ToTensor(),
+        transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+    ])
+    val_tfm = transforms.Compose([
+        transforms.Resize(256),
+        transforms.CenterCrop(224),
+        transforms.ToTensor(),
+        transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+    ])
+
+    train_ds = datasets.ImageFolder(data_dir / "train", transform=train_tfm)
+    val_ds = datasets.ImageFolder(data_dir / "val", transform=val_tfm)
+
+    train_dl = DataLoader(train_ds, batch_size=batch_size, shuffle=True, num_workers=num_workers)
+    val_dl = DataLoader(val_ds, batch_size=batch_size, shuffle=False, num_workers=num_workers)
+
+    return train_dl, val_dl, len(train_ds.classes)
+
+
+def build_model(num_classes: int):
+    model = models.resnet50(weights=models.ResNet50_Weights.DEFAULT)
+    in_features = model.fc.in_features
+    model.fc = nn.Linear(in_features, num_classes)
+    return model
+
+
+def accuracy(preds, targets):
+    _, pred_labels = torch.max(preds, 1)
+    return (pred_labels == targets).float().mean().item()
+
+
+def train_epoch(model, loader, criterion, optimizer, scheduler, device):
+    model.train()
+    running_loss = 0.0
+    running_acc = 0.0
+    for images, labels in loader:
+        images, labels = images.to(device), labels.to(device)
+        optimizer.zero_grad()
+        outputs = model(images)
+        loss = criterion(outputs, labels)
+        loss.backward()
+        optimizer.step()
+        scheduler.step()
+
+        running_loss += loss.item() * images.size(0)
+        running_acc += accuracy(outputs, labels) * images.size(0)
+
+    epoch_loss = running_loss / len(loader.dataset)
+    epoch_acc = running_acc / len(loader.dataset)
+    return epoch_loss, epoch_acc
+
+
+def evaluate(model, loader, criterion, device):
+    model.eval()
+    running_loss = 0.0
+    running_acc = 0.0
+    with torch.no_grad():
+        for images, labels in loader:
+            images, labels = images.to(device), labels.to(device)
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+            running_loss += loss.item() * images.size(0)
+            running_acc += accuracy(outputs, labels) * images.size(0)
+
+    epoch_loss = running_loss / len(loader.dataset)
+    epoch_acc = running_acc / len(loader.dataset)
+    return epoch_loss, epoch_acc
+
+
+def main():
+    args = parse_args()
+    args.output.mkdir(parents=True, exist_ok=True)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    train_dl, val_dl, num_classes = get_dataloaders(args.data_dir, args.batch_size, args.num_workers)
+    model = build_model(num_classes).to(device)
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.SGD(model.parameters(), lr=args.lr, momentum=0.9, weight_decay=1e-4)
+    total_steps = args.epochs * len(train_dl)
+    scheduler = torch.optim.lr_scheduler.OneCycleLR(optimizer, max_lr=args.lr, total_steps=total_steps)
+
+    metrics = {"train_loss": [], "train_acc": [], "val_loss": [], "val_acc": []}
+
+    for epoch in range(1, args.epochs + 1):
+        tr_loss, tr_acc = train_epoch(model, train_dl, criterion, optimizer, scheduler, device)
+        val_loss, val_acc = evaluate(model, val_dl, criterion, device)
+
+        metrics["train_loss"].append(tr_loss)
+        metrics["train_acc"].append(tr_acc)
+        metrics["val_loss"].append(val_loss)
+        metrics["val_acc"].append(val_acc)
+
+        print(f"Epoch {epoch}/{args.epochs} - "
+              f"train_loss: {tr_loss:.4f} train_acc: {tr_acc:.4f} "
+              f"val_loss: {val_loss:.4f} val_acc: {val_acc:.4f}")
+
+    torch.save(model.state_dict(), args.output / "model.pth")
+    with open(args.output / "metrics.json", "w") as f:
+        json.dump(metrics, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a standalone training script using `torchvision` and `OneCycleLR`

## Testing
- `python -m py_compile src/train.py`


------
https://chatgpt.com/codex/tasks/task_e_6879c357c6a08325a86c709b218b9fa5