### PR TITLE
Add torchvision augmentations with CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,21 @@ What does a sample picture look like using a combination of RandomRotateZoom + A
  
  #### Data Augmentation Experimentation [Towards Data Science](https://towardsdatascience.com/data-augmentation-experimentation-3e274504f04b).
  
- #### Data Augmentation Using Fastai [Becoming Human](https://becominghuman.ai/data-augmentation-using-fastai-aefa88ca03f1)
+#### Data Augmentation Using Fastai [Becoming Human](https://becominghuman.ai/data-augmentation-using-fastai-aefa88ca03f1)
+
+### PyTorch training script
+
+The `src/train.py` script reproduces the augmentations explored above using
+`torchvision.transforms`. You can control each augmentation from the command
+line:
+
+```
+python src/train.py DATA_DIR \
+    --rotation 20 --zoom 0.2 --brightness 0.1 --contrast 0.1 \
+    --pad 50 --dihedral --cutout 0.4
+```
+
+This mirrors the `RandomZoomRotate`, `Padding`, `RandomLighting`+`Dihedral` and
+`Cutout` experiments for easy comparison.
+
 


### PR DESCRIPTION
## Summary
- extend `src/train.py` with configurable torchvision augmentations
- document how to use the new training script and options in README

## Testing
- `python -m py_compile src/train.py`


------
https://chatgpt.com/codex/tasks/task_e_6879c471bf808325a221fc1ec4899530